### PR TITLE
Bump pl.project13.maven:git-commit-id-plugin from 2.2.6 to 4.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 			<plugin>
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>
-				<version>2.2.6</version>
+				<version>4.9.10</version>
 				<executions>
 					<execution>
 						<id>get-the-git-infos</id>


### PR DESCRIPTION
Bumps pl.project13.maven:git-commit-id-plugin from 2.2.6 to 4.9.10.

---
updated-dependencies:
- dependency-name: pl.project13.maven:git-commit-id-plugin dependency-type: direct:production update-type: version-update:semver-major ...